### PR TITLE
Now component_iid() macro return a reference to uuid_t.

### DIFF
--- a/lib/libcomponent/component/base.h
+++ b/lib/libcomponent/component/base.h
@@ -55,7 +55,7 @@
   }
 
 #define DECLARE_COMPONENT_UUID(f1,f2,f3,f4,f5,f6,f7,f8,f9,f10)             \
-  static Component::uuid_t component_id() {                                \
+  static Component::uuid_t& component_id() {                                \
     static Component::uuid_t comp_uuid = {f1,f2,f3,f4,{f5,f6,f7,f8,f9,f10}}; \
     return comp_uuid;                                               \
   }


### PR DESCRIPTION
This is to make macros DECLARE_INTERFACE_UUID and DECLARE_COMPONENT_UUID look similar.
It also eases the use of functions/methods that receive a component's uuid_t& as a parameter. 
