### PR TITLE
Added two 'rdtscp' functions that return a timestamp counter read alo…

### DIFF
--- a/lib/libcommon/common/cycles.h
+++ b/lib/libcommon/common/cycles.h
@@ -30,6 +30,7 @@
 /*
   Authors:
   Copyright (C) 2013, Daniel G. Waddington <d.waddington@samsung.com>
+  Copyright (C) 2015, Juan A. Colmenares <juan.col@samsung.com>
 */
 
 #ifndef __CYCLES_H__
@@ -46,7 +47,7 @@
 #if defined(__amd64__)
 
 /** 
- * Reads complete 40 bit counter into 64 bit value.
+ * Reads the timestamp counter.
  * @return the read value. 
  */
 INLINE cpu_time_t rdtsc() {
@@ -65,6 +66,50 @@ INLINE uint32_t rdtsc_low() {
   asm volatile("lfence"); // should be mfence for AMD
   asm volatile("rdtsc" : "=a" (a)); //, "=d" (d)); 
   return a;
+}
+
+/**
+ * Returns the content of the timestamp counter (TSC) as well as the content of
+ * the 32-bit Machine-Specific-Register MSR_TSC_AUX, which stores a value that
+ * is unique to each logical processor. 
+ *
+ * Linux kernels (since about 2.6.34) use the MSR_TSC_AUX register to store the
+ * logical processor number and the socket number where that logical processor
+ * is located (in multi-socket systems).
+ *
+ * @param[out] aux the content of MSR_TSC_AUX register. 
+ * @return the timestamp counter's value. 
+ */
+INLINE 
+cpu_time_t rdtscp(uint32_t& aux) {
+  unsigned a, d, c;
+  asm volatile("lfence"); // should be mfence for AMD
+  asm volatile("rdtscp" : "=a" (a), "=d" (d), "=c" (aux));
+  return ((unsigned long long)a) | (((unsigned long long)d) << 32);;
+}
+
+
+/**
+ * Returns a timestamp counter (TSC) read, the number of the socket where the
+ * current processor is located, and the current processor's logical number. 
+ *
+ * Linux kernels (since about 2.6.34) use the 32-bit MSR_TSC_AUX register to
+ * store the logical processor number and (in multi-socket systems) the socket
+ * number where that logical processor is located.  
+ * The value stored in MSR_TSC_AUX is unique to each logical processor.  
+ *
+ * @param[out] socket_id the number of the socket for the current processor.  
+ * @param[out] cpu_id the current processor's logical number. 
+ * @return the timestamp counter's value. 
+ */
+INLINE 
+cpu_time_t rdtscp(uint32_t& socket_id, uint32_t& cpu_id) {
+  unsigned a, d, c;
+  asm volatile("lfence"); // should be mfence for AMD
+  asm volatile("rdtscp" : "=a" (a), "=d" (d), "=c" (c));
+  socket_id = (c & 0xFFF000)>>12;
+  cpu_id = c & 0xFFF;
+  return ((unsigned long long)a) | (((unsigned long long)d) << 32);;
 }
 
 

--- a/testing/libs/rdtscp/Makefile
+++ b/testing/libs/rdtscp/Makefile
@@ -1,0 +1,10 @@
+include ../../../mk/global.mk
+
+all: rdtscp-test
+
+rdtscp-test:
+	g++ $(XDK_INCLUDES) $(XDK_LIBS) -o rdtscp-test main.cc
+
+clean:
+	rm -f *.o rdtscp-test
+

--- a/testing/libs/rdtscp/main.cc
+++ b/testing/libs/rdtscp/main.cc
@@ -1,0 +1,42 @@
+#include <unistd.h>
+
+#include <common/types.h>
+#include <common/cycles.h>
+#include <common/logging.h>
+
+/** 
+ * Test program for rdtscp functions in common/cycles.h.
+ *
+ * To verify that the returned values of aux, socket_id and cpu_id are correct,
+ * you can use the 'tasklet' tool as follows:
+ * + $> tasklet <COREMASK> <EXECUTABLE>
+ *
+ * For example:
+ * + $> tasklet 0x2 ./rdtscp-test.
+ *
+ * To install taskset on Debian, Ubuntu or Linux Mint:
+ * $> sudo apt-get install util-linux
+ *
+ * To install taskset on Fedora, CentOS or RHEL:
+ * $> sudo yum install util-linux 
+ */
+int main() {
+
+  PINF("Testing...");
+
+  uint32_t aux = 0;
+  cpu_time_t t0 = rdtscp(aux);
+  PINF("t0 = %lu, aux = %d", t0, aux);
+
+
+  usleep(10*1000);
+
+  uint32_t socket_id = 0; 
+  uint32_t cpu_id = 0; 
+  cpu_time_t t1 = rdtscp(socket_id, cpu_id);
+  PINF("t1 = %lu, socket_id = %d, cpu_id = %d", t1, socket_id, cpu_id);
+
+  PINF("Test OK.");
+  return 0;
+}
+


### PR DESCRIPTION
…ng with the value of MSR_TSC_AUX and the socket ID and the logical cpu ID.
