### PR TITLE
Unstable

### DIFF
--- a/examples/components/base-example/Makefile
+++ b/examples/components/base-example/Makefile
@@ -1,6 +1,6 @@
 include ../../../mk/global.mk
 
-CXXFLAGS += -g $(XDK_INCLUDES)
+CXXFLAGS += -g -std=c++11 $(XDK_INCLUDES)
 BOOST_LIBS = -lboost_thread
 LIBS = $(XDK_LIBS) -ldl $(BOOST_LIBS)
 

--- a/examples/components/block-device/Makefile
+++ b/examples/components/block-device/Makefile
@@ -1,6 +1,6 @@
 include ../../../mk/global.mk
 
-CXXFLAGS += -g $(XDK_INCLUDES)
+CXXFLAGS += -g -std=c++11 $(XDK_INCLUDES)
 BOOST_LIBS = -lboost_thread
 LIBS = $(XDK_LIBS) -ldl $(BOOST_LIBS)
 

--- a/lib/libcommon/common/cpu_mask.h
+++ b/lib/libcommon/common/cpu_mask.h
@@ -13,7 +13,7 @@ private:
 
 public:
   cpu_mask_t() {
-    memset(&cpu_set_,0,sizeof(cpu_set_t));
+    __builtin_memset(&cpu_set_,0,sizeof(cpu_set_t));
   }
 
   void set_bit(int cpu) {


### PR DESCRIPTION
added -std=c++11 flags, otherwise examples code did not compile
